### PR TITLE
Translate weapons compendium to pt-BR

### DIFF
--- a/compendium/daggerheart.weapons.json
+++ b/compendium/daggerheart.weapons.json
@@ -1,15 +1,15 @@
 {
-	"label": "Weapons",
+	"label": "Armas",
 	"folders": {
-		"Combat Wheelchairs": "Sillas de ruedas de combate",
-		"Primary Weapons": "Armas principales",
-		"Secondary Weapons": "Armas secundarias",
+		"Combat Wheelchairs": "Cadeiras de rodas de combate",
+		"Primary Weapons": "Armas principais",
+		"Secondary Weapons": "Armas secundárias",
 		"Magical Weapons": "Armas mágicas",
 		"Physical Weapons": "Armas físicas",
-		"Tier 1": "Rango 1",
-		"Tier 2": "Rango 2",
-		"Tier 3": "Rango 3",
-		"Tier 4": "Rango 4"
+		"Tier 1": "Nível 1",
+		"Tier 2": "Nível 2",
+		"Tier 3": "Nível 3",
+		"Tier 4": "Nível 4"
 	},
 	"entries": {}
 }


### PR DESCRIPTION
## Summary
- translate daggerheart weapons compendium entries to Brazilian Portuguese

## Testing
- `jq . compendium/daggerheart.weapons.json`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af7f9137d08322bfc39eaa5c436c6f