### PR TITLE
Rename Finesse ability to Sutilza

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1017,8 +1017,8 @@
                     }
                 },
                 "finesse": {
-                    "name": "Finesse",
-                    "short": "FIN",
+                    "name": "Sutilza",
+                    "short": "SUT",
                     "verb": {
                         "control": "Control",
                         "hide": "Hide",
@@ -1142,11 +1142,11 @@
                 },
                 "cumbersome": {
                     "name": "Cumbersome",
-                    "description": "-1 to Finesse",
+                    "description": "-1 to Sutilza",
                     "effects": {
                         "cumbersome": {
                             "name": "Cumbersome",
-                            "description": "-1 to Finesse"
+                            "description": "-1 to Sutilza"
                         }
                     }
                 },

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1078,8 +1078,8 @@
             }
           },
           "finesse": {
-            "name": "Finesse",
-            "short": "FIN",
+            "name": "Sutilza",
+            "short": "SUT",
             "verb": {
               "control": "Controlar",
               "hide": "Esconder",
@@ -1203,11 +1203,11 @@
         },
         "cumbersome": {
           "name": "Desajeitado",
-          "description": "-1 em Finesse",
+          "description": "-1 em Sutilza",
           "effects": {
             "cumbersome": {
               "name": "Desajeitado",
-              "description": "-1 em Finesse"
+              "description": "-1 em Sutilza"
             }
           }
         },


### PR DESCRIPTION
## Summary
- rename Finesse to Sutilza and update abbreviation to SUT
- adjust ability descriptions referencing Finesse

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af8ec121e083228e1056ebd80be8b0