### PR TITLE
Corrige termos em espanhol para português brasileiro

### DIFF
--- a/compendium/daggerheart._packs-folders.json
+++ b/compendium/daggerheart._packs-folders.json
@@ -1,7 +1,7 @@
 {
     "entries": {
         "Daggerheart SRD": "SRD de Daggerheart",
-        "Character Options": "Opciones de Personaje",
-        "Items": "Objetos"
+        "Character Options": "Opções de Personagem",
+        "Items": "Itens"
     }
 }


### PR DESCRIPTION
## Descrição

Corrige termos em espanhol que estavam incorretos no arquivo :

- **'Opciones de Personaje'** → **'Opções de Personagem'** (corrigido de espanhol para português)
- **'Objetos'** → **'Itens'** (termo mais apropriado em português brasileiro)

## Arquivos alterados
- 

## Tipo de mudança
- [x] Correção de bug (tradução incorreta)
- [x] Melhoria na tradução

## Checklist
- [x] Código testado localmente
- [x] Commit com mensagem descritiva
- [x] Branch baseada na main atualizada